### PR TITLE
excluded user from follow count and other fixes

### DIFF
--- a/routes/html-routes.js
+++ b/routes/html-routes.js
@@ -189,7 +189,7 @@ module.exports = function(app) {
             userId: userId
           }
         }).then(result => {
-          const followingCount = result.count;
+          const followingCount = result.count - 1;  //adjusting for follow-self relationship
 
           db.Review.findAndCountAll({
             where: {
@@ -211,9 +211,17 @@ module.exports = function(app) {
                 user => user.dataValues.followedId
               );
 
-              let alreadyFollowed = false;
-              if (usersFollowed.indexOf(userId) > -1) {
-                alreadyFollowed = true;
+              let userStatus = {
+                followed: false,
+                notFollowed: false,
+                self: false
+              };
+              if (usersFollowed.indexOf(userId) > -1 && userId !== req.user.id) {
+                userStatus.followed = true;
+              } else if (userId === req.user.id) {
+                userStatus.self = true;
+              } else {
+                userStatus.notFollowed = true;
               }
 
               db.Review.findAll({
@@ -242,7 +250,7 @@ module.exports = function(app) {
                 const data = {
                   loginUserId: loginUserID,
                   profileUserId: userId,
-                  alreadyFollowed: alreadyFollowed,
+                  userStatus: userStatus,
                   username: username,
                   followingCount: followingCount,
                   reviewCount: reviewCount,

--- a/views/user.handlebars
+++ b/views/user.handlebars
@@ -18,13 +18,16 @@
       FOLLOWING {{followingCount}} USERS
      </p>
      <div id="followStatus">
-      {{#if alreadyFollowed}}
-      <p class="font-weight-bold">
-       You are following this user!
-      </p>
-      {{else}}
-      <button class="btn btn-dark" id="createFollow">Follow</button>
-      {{/if}}
+      {{#with userStatus}}
+        {{#if followed}}
+        <p class="font-weight-bold">
+        You are following this user!
+        </p>
+        {{/if}}
+        {{#if notFollowed}}
+        <button class="btn btn-dark" id="createFollow">Follow</button>
+        {{/if}}
+      {{/with}}
      </div>
     </div>
    </div>


### PR DESCRIPTION
User's self-follow relationship is no longer counted in their following count on User page.

Instead of always showing either "You're already following" message or a Follow button, we will now show neither when the user is viewing their own profile.